### PR TITLE
Dockerfile to use debian. Bun update to 3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jarredsumner/bun:edge AS runner
+FROM debian:latest AS runner
 
 WORKDIR /app
 
@@ -23,7 +23,12 @@ RUN addgroup \
 
 COPY package.json bun.lockb ./
 
-RUN bun install
+RUN apt-get update && apt-get install -y curl unzip
+
+RUN curl https://bun.sh/install | bash
+RUN $HOME/.bun/bin/bun install
+RUN cp $HOME/.bun/bin/bun /bin
+RUN bun upgrade --canary
 
 COPY . .
 


### PR DESCRIPTION
This changes to debian base so Bun can be updated to 3.0 canary build. This allows for avx support and resolves segfault errors. Should also see a good performance gain

I don't know if there are any issues with how I did the Bun install here - and i'm not sure what gitlab runner really is, so I just left it. Let me know if there are any issues! 

This is per issue #73 